### PR TITLE
fix: remove unnecessary blank line in self-executing function

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,7 +42,6 @@ declare const __LICENSE__: string
 		console.groupEnd()
 
 		if (typeof window !== 'undefined') {
-
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(window as any).__DYNAMIX_LAYOUT__ = {
 				__LICENSE__: __LICENSE__,


### PR DESCRIPTION
This pull request includes a minor change in the `packages/core/src/index.ts` file. The change removes an unnecessary blank line within the `if (typeof window !== 'undefined')` block, improving code readability.