### PR TITLE
chore: add changeset for version bump to 0.0.3

### DIFF
--- a/.changeset/beige-chefs-cheat.md
+++ b/.changeset/beige-chefs-cheat.md
@@ -1,0 +1,5 @@
+---
+'@dynamix-layout/core': patch
+---
+
+chore: bump version to 0.0.3


### PR DESCRIPTION
This pull request includes a minor change to the `.changeset/beige-chefs-cheat.md` file. The change increments the version of the `@dynamix-layout/core` package to `0.0.3` as a patch update.