### PR TITLE
feat: update test task to depend on build task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,7 @@
 			"dependsOn": ["^check-types"]
 		},
 		"test": {
+			"dependsOn": ["^build"],
 			"outputs": []
 		},
 		"dev": {


### PR DESCRIPTION
This pull request includes a small change to the `turbo.json` file. The change ensures that the `test` task now depends on the `build` task, likely to enforce that the build process is completed before running tests.