### PR TITLE
feat: add server dependencies configuration for testing environment [react]

### DIFF
--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -15,6 +15,11 @@ export default defineConfig({
 		globals: true,
 		environment: 'jsdom',
 		setupFiles: './src/test/setup.ts',
+		server: {
+			deps: {
+				inline: ['@dynamix-layout/core']
+			}
+		}
 	},
 	build: {
 		sourcemap: 'hidden',


### PR DESCRIPTION
This pull request makes a configuration change to the Vite setup for the React package. The change ensures that specific dependencies are inlined during the server build process.

Configuration changes:

* [`packages/react/vite.config.ts`](diffhunk://#diff-28dac5df05657e5e97b4a2230a26f8314d5920e563809a5422407526e813291aR18-R22): Added a `server.deps.inline` configuration to inline the `@dynamix-layout/core` dependency during the development server build.