### PR TITLE
feat: add alias configuration for module resolution in Vite

### DIFF
--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -59,6 +59,10 @@ export default defineConfig({
 	],
 	resolve: {
 		preserveSymlinks: true,
+		alias: [
+			{ find: '@', replacement: resolve(__dirname, './src') },
+			{ find: '@dynamix-layout/core', replacement: resolve(__dirname, '../core/src') }
+		]
 	},
 	css: {
 		modules: {


### PR DESCRIPTION
This pull request updates the Vite configuration in the `packages/react/vite.config.ts` file to improve module resolution by adding path aliases.

Configuration updates:

* Added path aliases to the `resolve.alias` array: 
  - `@` now maps to the `./src` directory.
  - `@dynamix-layout/core` now maps to the `../core/src` directory.