### PR TITLE
feat: add license definition to Vite configuration

### DIFF
--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -5,8 +5,14 @@ import dts from 'vite-plugin-dts'
 import { libInjectCss } from 'vite-plugin-lib-inject-css'
 import { visualizer } from 'rollup-plugin-visualizer'
 import stripComments from 'vite-plugin-strip-comments'
+import fs from 'fs'
+
+const license = fs.readFileSync(resolve(__dirname, '../../LICENSE'), 'utf-8')
 
 export default defineConfig({
+	define: {
+		__LICENSE__: JSON.stringify(license),
+	},
 	server: {
 		port: 5174,
 		open: false,


### PR DESCRIPTION
This pull request introduces changes to the `vite.config.ts` file to include the project's license content as a global constant. The most important change is the addition of a new `define` property in the Vite configuration.

### Changes to Vite configuration:

* [`packages/react/vite.config.ts`](diffhunk://#diff-28dac5df05657e5e97b4a2230a26f8314d5920e563809a5422407526e813291aR8-R15): Added the `fs` module to read the `LICENSE` file and defined a global constant `__LICENSE__` containing the license content. This allows the license text to be accessed throughout the application.