### PR TITLE
fix: update demo gif in README files

### DIFF
--- a/.changeset/fine-wings-watch.md
+++ b/.changeset/fine-wings-watch.md
@@ -1,0 +1,5 @@
+---
+'@dynamix-layout/core': patch
+---
+
+Fixed demo gif.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Dynamix Layout is a powerful JavaScript library designed to help you build compl
 
 ---
 
-![Demo](https://raw.githubusercontent.com/akash-aman/dynamix-layout/main/assets/demo.gif)
+![Demo](https://raw.githubusercontent.com/akash-aman/dynamix-layout/main/assets/demo1.gif)
 
 ---
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,7 +18,7 @@
 
 ---
 
-![alt text](https://raw.githubusercontent.com/akash-aman/dynamix-layout/main/assets/demo.gif)
+![alt text](https://raw.githubusercontent.com/akash-aman/dynamix-layout/main/assets/demo1.gif)
 
 ---
 


### PR DESCRIPTION
This pull request fixes an issue with the demo GIF used in the documentation for the `@dynamix-layout/core` package. The changes ensure the correct demo GIF is displayed.

Documentation updates:

* [`.changeset/fine-wings-watch.md`](diffhunk://#diff-3f10f935f6261043c6379c21f8e6bb646001a252a355adb6907ede65c1323688R1-R5): Added a patch note indicating that the demo GIF was fixed.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R38): Updated the demo GIF link to point to the correct file (`demo1.gif`).
* [`packages/core/README.md`](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L21-R21): Updated the demo GIF link to the correct file (`demo1.gif`).