### PR TITLE
fix: update @dynamix-layout/core dependency to use workspace version

### DIFF
--- a/.changeset/solid-donuts-stand.md
+++ b/.changeset/solid-donuts-stand.md
@@ -1,0 +1,5 @@
+---
+'@dynamix-layout/react': patch
+---
+
+- Fixed demo gif.

--- a/examples/shadcn/package.json
+++ b/examples/shadcn/package.json
@@ -10,7 +10,7 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"@dynamix-layout/core": "^0.0.5",
+		"@dynamix-layout/core": "workspace:*",
 		"@dynamix-layout/react": "workspace:*",
 		"@monaco-editor/react": "^4.7.0",
 		"@radix-ui/react-slider": "^1.3.5",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -14,13 +14,13 @@
 
 **@dynamix-layout/react** brings the power of the `@dynamix-layout/core` engine to React applications. It provides a flexible `<DynamixLayout />` component and an advanced `useDynamixLayout` hook to create fully dynamic, resizable, and draggable tab-based layouts with ease. Build complex UIs like VS Code or JSFiddle in minutes.
 
------
+---
 
 ### Made with ❤️ by [Akash Aman](https://linktr.ee/akash_aman)
 
 ---
 
-![Demo](https://raw.githubusercontent.com/akash-aman/dynamix-layout/main/assets/demo.gif)
+![Demo](https://raw.githubusercontent.com/akash-aman/dynamix-layout/main/assets/demo1.gif)
 
 ---
 
@@ -30,7 +30,7 @@
 npm install @dynamix-layout/react @dynamix-layout/core
 ```
 
------
+---
 
 ## 🏁 Getting Started
 
@@ -42,30 +42,30 @@ import { DynamixLayout } from '@dynamix-layout/react'
 import '@dynamix-layout/react/dist/layout.css' // Don't forget to import the default styles
 
 function App() {
-    // 1. Define your tabs as an array of [id, component] tuples
-    const myTabs = [
-        ['editor', <div>This is my editor!</div>],
-        ['terminal', <div>This is the terminal.</div>],
-        ['preview', <div>Live preview here.</div>],
-    ]
+	// 1. Define your tabs as an array of [id, component] tuples
+	const myTabs = [
+		['editor', <div>This is my editor!</div>],
+		['terminal', <div>This is the terminal.</div>],
+		['preview', <div>Live preview here.</div>],
+	]
 
-    return (
-        <div
-            style={{
-                width: '100vw',
-                height: '100vh',
-            }}
-        >
-            {/* 2. Render the DynamixLayout component with your tabs */}
-            <DynamixLayout tabs={myTabs} />
-        </div>
-    )
+	return (
+		<div
+			style={{
+				width: '100vw',
+				height: '100vh',
+			}}
+		>
+			{/* 2. Render the DynamixLayout component with your tabs */}
+			<DynamixLayout tabs={myTabs} />
+		</div>
+	)
 }
 
 export default App
 ```
 
------
+---
 
 ## 🧩 `<DynamixLayout />` Component API
 
@@ -73,23 +73,23 @@ The `<DynamixLayout />` component is the primary way to use this package. It's h
 
 ### Core Functionality
 
-| Prop                   | Type                     | Description                                                                           | Default                          |
-| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------- | -------------------------------- |
-| **`tabs`** (required)  | `[string, ReactNode][]`  | An array of `[id, component]` tuples for your tabs.                                   | `         `                          |
-| `layoutTree`           | `LayoutTree`             | A serialized layout object from a previous session to restore a saved layout.         | `null`                           |
-| `tabNames`             | `Map<string, string>`    | An optional map to provide friendly display names for your tabs in the tab bar.       | `new Map()`                      |
-| `enableTabbar`         | `boolean`                | If `true`, renders the draggable tab bar on top of each tab panel.                    | `true`                           |
-| `tabHeadHeight`        | `number`                 | The height of the tab bar in pixels.                                                  | `40`                             |
-| `pad`                  | `{ t, b, l, r }`         | Padding for the root layout container in pixels.                                      | `{ t: 0, b: 0, l: 0, r: 0 }`     |
-| `minTabWidth`          | `number`                 | Minimum width of a tab panel in pixels.                                               | `40`                             |
-| `minTabHeight`         | `number`                 | Minimum height of a tab panel in pixels.                                              | `40`                             |
-| `bondWidth`            | `number`                 | The width/height of the draggable slider between panels in pixels.                    | `10`                             |
-| `rootId`               | `string`                 | The HTML `id` for the root `<div>` element of the layout.                             | `"dynamix-layout-root"`          |
-| `disableResizeTimeout` | `boolean`                | Disables debounce on window resize for faster updates. Can impact performance.        | `true`                           |
-| `disableSliderTimeout` | `boolean`                | Disables debounce when dragging a slider.                                             | `true`                           |
-| `windowResizeTimeout`  | `number`                 | Debounce timeout in milliseconds for window resize events.                            | `2`                              |
-| `sliderUpdateTimeout`  | `number`                 | Debounce timeout in milliseconds for slider drag events.                              | `2`                              |
-| `...props`             | `HTMLAttributes`         | Standard HTML attributes like `style` and `className` are passed to the root `<div>`. | `         `                          |
+| Prop                   | Type                    | Description                                                                           | Default                      |
+| ---------------------- | ----------------------- | ------------------------------------------------------------------------------------- | ---------------------------- |
+| **`tabs`** (required)  | `[string, ReactNode][]` | An array of `[id, component]` tuples for your tabs.                                   | `         `                  |
+| `layoutTree`           | `LayoutTree`            | A serialized layout object from a previous session to restore a saved layout.         | `null`                       |
+| `tabNames`             | `Map<string, string>`   | An optional map to provide friendly display names for your tabs in the tab bar.       | `new Map()`                  |
+| `enableTabbar`         | `boolean`               | If `true`, renders the draggable tab bar on top of each tab panel.                    | `true`                       |
+| `tabHeadHeight`        | `number`                | The height of the tab bar in pixels.                                                  | `40`                         |
+| `pad`                  | `{ t, b, l, r }`        | Padding for the root layout container in pixels.                                      | `{ t: 0, b: 0, l: 0, r: 0 }` |
+| `minTabWidth`          | `number`                | Minimum width of a tab panel in pixels.                                               | `40`                         |
+| `minTabHeight`         | `number`                | Minimum height of a tab panel in pixels.                                              | `40`                         |
+| `bondWidth`            | `number`                | The width/height of the draggable slider between panels in pixels.                    | `10`                         |
+| `rootId`               | `string`                | The HTML `id` for the root `<div>` element of the layout.                             | `"dynamix-layout-root"`      |
+| `disableResizeTimeout` | `boolean`               | Disables debounce on window resize for faster updates. Can impact performance.        | `true`                       |
+| `disableSliderTimeout` | `boolean`               | Disables debounce when dragging a slider.                                             | `true`                       |
+| `windowResizeTimeout`  | `number`                | Debounce timeout in milliseconds for window resize events.                            | `2`                          |
+| `sliderUpdateTimeout`  | `number`                | Debounce timeout in milliseconds for slider drag events.                              | `2`                          |
+| `...props`             | `HTMLAttributes`        | Standard HTML attributes like `style` and `className` are passed to the root `<div>`. | `         `                  |
 
 ### 🎨 Customization with Wrapper Components
 
@@ -111,21 +111,21 @@ import { DynamixLayout } from '@dynamix-layout/react'
 import React from 'react'
 
 const MyCustomSlider = React.forwardRef((props, ref) => (
-    <div
-        ref={ref}
-        {...props}
-        style={{
-            ...props.style,
-            background: 'rgba(255, 0, 0, 0.5)',
-            border: '1px dashed red',
-            zIndex: 100, // Ensure it's on top
-        }}
-    />
+	<div
+		ref={ref}
+		{...props}
+		style={{
+			...props.style,
+			background: 'rgba(255, 0, 0, 0.5)',
+			border: '1px dashed red',
+			zIndex: 100, // Ensure it's on top
+		}}
+	/>
 ))
 
 function App() {
-    // ... (myTabs definition)
-    return <DynamixLayout tabs={myTabs} SliderElement={MyCustomSlider} />
+	// ... (myTabs definition)
+	return <DynamixLayout tabs={myTabs} SliderElement={MyCustomSlider} />
 }
 ```
 
@@ -133,24 +133,24 @@ function App() {
 
 For finer-grained control, you can pass `style` objects or `className` strings to the default wrapper components without replacing them entirely.
 
-| Prop                        | Type                  | Target Element           |
-| --------------------------- | --------------------- | ------------------------ |
-| `tabPanelElementStyles`     | `React.CSSProperties` | `WrapTabPanel`           |
-| `tabPanelElementClass`      | `string`              | `WrapTabPanel`           |
-| `tabHeadElementStyles`      | `React.CSSProperties` | `WrapTabHead`            |
-| `tabHeadElementClass`       | `string`              | `WrapTabHead`            |
-| `tabLabelElementStyles`     | `React.CSSProperties` | `WrapTabLabel`           |
-| `tabLabelElementClass`      | `string`              | `WrapTabLabel`           |
-| `tabBodyElementStyles`      | `React.CSSProperties` | `WrapTabBody`            |
-| `tabBodyElementClass`       | `string`              | `WrapTabBody`            |
-| `sliderElementStyles`       | `React.CSSProperties` | `SliderElement`          |
-| `sliderElementClass`        | `string`              | `SliderElement`          |
-| `hoverElementStyles`        | `React.CSSProperties` | `HoverElement`           |
-| `hoverElementClass`         | `string`              | `HoverElement`           |
-| `RootSplitterHoverElStyles` | `React.CSSProperties` | Root edge drop zones     |
-| `RootSplitterHoverElClass`  | `string`              | Root edge drop zones     |
+| Prop                        | Type                  | Target Element       |
+| --------------------------- | --------------------- | -------------------- |
+| `tabPanelElementStyles`     | `React.CSSProperties` | `WrapTabPanel`       |
+| `tabPanelElementClass`      | `string`              | `WrapTabPanel`       |
+| `tabHeadElementStyles`      | `React.CSSProperties` | `WrapTabHead`        |
+| `tabHeadElementClass`       | `string`              | `WrapTabHead`        |
+| `tabLabelElementStyles`     | `React.CSSProperties` | `WrapTabLabel`       |
+| `tabLabelElementClass`      | `string`              | `WrapTabLabel`       |
+| `tabBodyElementStyles`      | `React.CSSProperties` | `WrapTabBody`        |
+| `tabBodyElementClass`       | `string`              | `WrapTabBody`        |
+| `sliderElementStyles`       | `React.CSSProperties` | `SliderElement`      |
+| `sliderElementClass`        | `string`              | `SliderElement`      |
+| `hoverElementStyles`        | `React.CSSProperties` | `HoverElement`       |
+| `hoverElementClass`         | `string`              | `HoverElement`       |
+| `RootSplitterHoverElStyles` | `React.CSSProperties` | Root edge drop zones |
+| `RootSplitterHoverElClass`  | `string`              | Root edge drop zones |
 
------
+---
 
 ## ⚙️ Advanced Usage: The `useDynamixLayout` Hook
 
@@ -167,10 +167,10 @@ The hook accepts an object with the same props as the `<DynamixLayout />` compon
 
 The hook returns an object with everything you need to build your UI, including:
 
-  - **State**: `tabsets` and `sliders` (Maps containing the layout data to render).
-  - **Refs**: `tabsetsRef`, `slidersRef`, `hoverElementRef`, etc., to connect to your DOM elements.
-  - **Event Handlers**: `onDragStart`, `onDragEnd`, `onDragOver`, `onPointerDown`, `updateActiveTab`, etc.
-  - **Instance**: `layoutInstance` (The raw instance of `@dynamix-layout/core` for advanced actions like saving state).
+- **State**: `tabsets` and `sliders` (Maps containing the layout data to render).
+- **Refs**: `tabsetsRef`, `slidersRef`, `hoverElementRef`, etc., to connect to your DOM elements.
+- **Event Handlers**: `onDragStart`, `onDragEnd`, `onDragOver`, `onPointerDown`, `updateActiveTab`, etc.
+- **Instance**: `layoutInstance` (The raw instance of `@dynamix-layout/core` for advanced actions like saving state).
 
 ### Example: Saving a Layout
 
@@ -181,7 +181,6 @@ import React, { useCallback, useRef } from 'react'
 import { DynamixLayoutCore, Node } from '@dynamix-layout/core'
 
 function MyCustomLayout() {
-
 	const handleSaveLayout = () => {
 		const layoutState = DynamixLayoutCore._root.toJSON()
 		localStorage.setItem('my-layout', JSON.stringify(layoutState))

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -74,7 +74,7 @@
 		"lint": "eslint . --ext ts,tsx"
 	},
 	"dependencies": {
-		"@dynamix-layout/core": "^0.0.5"
+		"@dynamix-layout/core": "workspace:*"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0 || ^18.0.0 || ^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
   examples/shadcn:
     dependencies:
       '@dynamix-layout/core':
-        specifier: ^0.0.5
-        version: 0.0.5
+        specifier: workspace:*
+        version: link:../../packages/core
       '@dynamix-layout/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -223,8 +223,8 @@ importers:
   packages/react:
     dependencies:
       '@dynamix-layout/core':
-        specifier: ^0.0.5
-        version: 0.0.5
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -598,10 +598,6 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
-
-  '@dynamix-layout/core@0.0.5':
-    resolution: {integrity: sha512-AcXMBvCAOAx32BYwatOw2Mlb+GxSGspWjMJeLkuyUYHpUag+utOrUybdhLkZmJrJuLIaJcT4ZQPmQr9798tvlA==}
-    engines: {node: '>=22.16.0', pnpm: '>=10.13.1'}
 
   '@emnapi/core@1.4.4':
     resolution: {integrity: sha512-A9CnAbC6ARNMKcIcrQwq6HeHCjpcBZ5wSx4U01WXCqEKlrzB9F9315WDNHkrs2xbx7YjjSxbUYxuN6EQzpcY2g==}
@@ -4679,8 +4675,6 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
-
-  '@dynamix-layout/core@0.0.5': {}
 
   '@emnapi/core@1.4.4':
     dependencies:


### PR DESCRIPTION
This pull request includes updates to the `@dynamix-layout` project, focusing on fixing a demo GIF, improving documentation, and aligning dependencies across the workspace. Below are the most important changes grouped by theme:

### Documentation Updates:
* Updated the demo GIF in `packages/react/README.md` to point to a new file (`demo1.gif`) for better clarity.
* Fixed table formatting issues in the `README.md` for `@dynamix-layout/react` to improve readability. [[1]](diffhunk://#diff-3dae6d110b675ef311b837cf10653c25945e787593bfc47d7bdbc3836df15abbL77-R77) [[2]](diffhunk://#diff-3dae6d110b675ef311b837cf10653c25945e787593bfc47d7bdbc3836df15abbL137-R137)

### Dependency Management:
* Changed the version of `@dynamix-layout/core` in `examples/shadcn/package.json` and `packages/react/package.json` to use `workspace:*` for consistency across the monorepo. [[1]](diffhunk://#diff-cbfbfb5114f693003fa57b3e113dc06291201125c60ec34cc29a34ece108fc70L13-R13) [[2]](diffhunk://#diff-1f344ac391eeecc21ec0f01fb07430a47f4b80d20485c125447d54c33c4bbfc4L77-R77)

### Changelog:
* Added a changeset file to document the patch release for `@dynamix-layout/react`, which includes the demo GIF fix.