### PR TITLE
chore: remove .npmrc configuration file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-use-node-version=22.16.0
-engine-strict=true


### PR DESCRIPTION
This pull request includes a small change to the `.npmrc` file. The change removes the `use-node-version` and `engine-strict` settings, likely to allow for more flexibility in Node.js versioning and dependency management.