### PR TITLE
fix: update links in README for issues page and license

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ export default App
 
 ## 🤝 Contributing
 
-Contributions, issues, and feature requests are welcome\! Feel free to check the [issues page](https://www.google.com/search?q=https://github.com/akash-aman/dynamix-layout/issues).
+Contributions, issues, and feature requests are welcome\! Feel free to check the [issues page](https://github.com/akash-aman/dynamix-layout/issues).
 
 ## 📝 License
 
-This project is [MIT](https://www.google.com/search?q=./LICENSE) licensed.
+This project is [MIT](./LICENSE) licensed.
 
 ---
 


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file. The change corrects the URLs for the issues page and license link to use direct and appropriate references.

- Updated the link to the issues page to point directly to the GitHub repository's issues section.
- Updated the license link to point directly to the local `LICENSE` file instead of a Google search query.