### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
       - '**'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/akash-aman/dynamix-layout/security/code-scanning/1](https://github.com/akash-aman/dynamix-layout/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block to the workflow to restrict the `GITHUB_TOKEN` permissions to the least privilege necessary. The workflow involves checking out the repository, setting up CI, and running tests, which typically only requires read access to repository contents. Therefore, the `permissions` block should grant `contents: read`. This can be added at the root of the workflow or specifically to the `test` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
