### PR TITLE
chore: update examples section in README with source and live demo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,12 @@ The official SolidJS wrapper for `@dynamix-layout/core`. It provides a flexible 
 
 This repository contains the following examples:
 
-- [Next.js](./examples/nextjs)
-- [React](./examples/react)
-- [Solid](./examples/solid)
-- [SolidStart](./examples/solidstart)
+| Example        | Source Link                | Live Demo Link                |
+|----------------|---------------------------|-------------------------------|
+| React          | [React](./examples/react)         | [dx.xcode.cx](https://dx.xcode.cx)                    |
+| Next.js        | [Next.js](./examples/nextjs)      | [nextjs.dx.xcode.cx](https://nextjs.dx.xcode.cx)      |
+| SolidJS          | [SolidJS](./examples/solid)         | [solidjs.dx.xcode.cx](https://solidjs.dx.xcode.cx)    |
+| SolidStart     | [SolidStart](./examples/solidstart)| [solidstart.dx.xcode.cx](https://solidstart.dx.xcode.cx) |
 
 ---
 

--- a/apps/site/src/components/Footer.tsx
+++ b/apps/site/src/components/Footer.tsx
@@ -231,6 +231,7 @@ const Footer = () => {
 								href="http://github.com/akash-aman/dynamix-layout"
 								target="_blank"
 								rel="noopener noreferrer"
+								title="GitHub Repository"
 							>
 								<Github className="w-4 h-4" />
 							</a>
@@ -245,6 +246,7 @@ const Footer = () => {
 								href="https://www.npmjs.com/org/dynamix-layout"
 								target="_blank"
 								rel="noopener noreferrer"
+								title="NPM Organization"
 							>
 								<ExternalLink className="w-4 h-4" />
 							</a>
@@ -259,6 +261,7 @@ const Footer = () => {
 								href="mailto:sir.akashaman@gmail.com"
 								target="_blank"
 								rel="noopener noreferrer"
+								title="Contact via Email"
 							>
 								<Mail className="w-4 h-4" />
 							</a>

--- a/apps/site/src/components/Header.tsx
+++ b/apps/site/src/components/Header.tsx
@@ -81,7 +81,7 @@ const Header = () => {
 							className="hidden sm:flex hover:bg-primary/10"
 							asChild
 						>
-							<a href="#demo">
+							<a href="#demo" title="Go to Demo section">
 								<ExternalLink className="w-4 h-4" />
 							</a>
 						</Button>

--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
 		"vite-plugin-strip-comments": "^0.0.6",
 		"vitest": "^3.2.4"
 	},
+	"pnpm": {
+		"overrides": {
+			"prismjs": "^1.30.0"
+		}
+	},
 	"packageManager": "pnpm@10.13.1",
 	"engines": {
 		"node": "^22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  prismjs: ^1.30.0
+
 importers:
 
   .:
@@ -6508,10 +6511,6 @@ packages:
   pretty-format@30.0.2:
     resolution: {integrity: sha512-yC5/EBSOrTtqhCKfLHqoUIAXVRZnukHPwWBJWR7h84Q3Be1DRQZLncwcfLoPA5RPQ65qfiCMqgYwdUuQ//eVpg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  prismjs@1.27.0:
-    resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
-    engines: {node: '>=6'}
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -14758,8 +14757,6 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  prismjs@1.27.0: {}
-
   prismjs@1.30.0: {}
 
   process-nextick-args@2.0.1: {}
@@ -15025,7 +15022,7 @@ snapshots:
     dependencies:
       hastscript: 6.0.0
       parse-entities: 2.0.0
-      prismjs: 1.27.0
+      prismjs: 1.30.0
 
   regex-recursion@5.1.1:
     dependencies:


### PR DESCRIPTION
This pull request updates the `README.md` file to improve the presentation of example projects by replacing a simple list with a table that includes both source links and live demo links.

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R97): Replaced the previous bullet-point list of examples with a table format that provides source links and live demo links for each example, including React, Next.js, SolidJS, and SolidStart.